### PR TITLE
:sparkles: Introduce a basic `Priceable` contract

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,5 @@
 <?php
-$finder = PhpCsFixer\Finder::create()->in(__DIR__ . '/src');
+$finder = PhpCsFixer\Finder::create()->in([__DIR__ . '/src', __DIR__ . '/tests']);
 
 return new PhpCsFixer\Config()
     ->setRules([

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
   "require": {
     "php": "^8.4",
     "ramsey/uuid": "^4.9",
-    "doctrine/collections": "^2.3"
+    "doctrine/collections": "^2.3",
+    "moneyphp/money": "^4.7"
   },
   "scripts": {
     "post-update-cmd": [

--- a/src/Core/Contract/Priceable.php
+++ b/src/Core/Contract/Priceable.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Contract;
+
+use Money\Money;
+
+interface Priceable
+{
+    public Money $price { get; set; }
+}

--- a/src/Ordering/Contract/DataObject/ProductData.php
+++ b/src/Ordering/Contract/DataObject/ProductData.php
@@ -2,7 +2,11 @@
 
 namespace Combee\Ordering\Contract\DataObject;
 
+use Money\Money;
+
 interface ProductData
 {
     public string $sku { get; }
+
+    public Money $price { get; }
 }

--- a/src/ProductCatalog/Contract/Model/ProductContract.php
+++ b/src/ProductCatalog/Contract/Model/ProductContract.php
@@ -2,7 +2,9 @@
 
 namespace Combee\ProductCatalog\Contract\Model;
 
-interface ProductContract
+use Combee\Core\Contract\Priceable;
+
+interface ProductContract extends Priceable
 {
     public string $sku { get; }
 }

--- a/src/ProductCatalog/Integration/Ordering/Provider/ProductDataProvider.php
+++ b/src/ProductCatalog/Integration/Ordering/Provider/ProductDataProvider.php
@@ -4,6 +4,7 @@ namespace Combee\ProductCatalog\Integration\Ordering\Provider;
 
 use Combee\Ordering\Contract\DataObject\ProductData;
 use Combee\Ordering\Contract\Provider\ProductDataProviderContract;
+use Money\Money;
 
 /**
  * @final
@@ -18,6 +19,10 @@ class ProductDataProvider implements ProductDataProviderContract
 
         return new class () implements ProductData {
             public string $sku = 'sku';
+
+            public Money $price {
+                get => Money::PLN(100);
+            }
         };
     }
 }

--- a/src/ProductCatalog/Model/Exception/NegativeOrZeroPriceException.php
+++ b/src/ProductCatalog/Model/Exception/NegativeOrZeroPriceException.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Combee\ProductCatalog\Model\Exception;
+
+use Money\Money;
+
+class NegativeOrZeroPriceException extends \LogicException
+{
+    public static function throwIfNotPositive(Money $value): void
+    {
+        if (!$value->isPositive()) {
+            throw new self('Price must be greater than zero.');
+        }
+    }
+}

--- a/src/ProductCatalog/Model/Product.php
+++ b/src/ProductCatalog/Model/Product.php
@@ -3,6 +3,8 @@
 namespace Combee\ProductCatalog\Model;
 
 use Combee\ProductCatalog\Contract\Model\ProductContract;
+use Combee\ProductCatalog\Model\Exception\NegativeOrZeroPriceException;
+use Money\Money;
 use Ramsey\Uuid\UuidInterface;
 
 class Product implements ProductContract
@@ -10,6 +12,14 @@ class Product implements ProductContract
     public function __construct(
         public readonly UuidInterface $uuid,
         public readonly string $sku,
+        public Money $price {
+            get => $this->price;
+            set {
+                NegativeOrZeroPriceException::throwIfNotPositive($value);
+
+                $this->price = $value;
+            }
+        }
     ) {
     }
 }

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,0 +1,31 @@
+# https://taskfile.dev
+
+version: '3'
+
+tasks:
+  cs:
+    cmds:
+      - tools/bin/php-cs-fixer check
+    silent: true
+
+  cs.fix:
+    cmds:
+      - tools/bin/php-cs-fixer fix
+    silent: true
+
+  phpstan:
+    cmds:
+      - tools/bin/phpstan analyse
+    silent: true
+
+  phpunit:
+    cmds:
+      - tools/bin/phpunit
+    silent: true
+
+  ci:
+    cmds:
+      - task: cs
+      - task: phpstan
+      - task: phpunit
+    silent: true

--- a/tests/Architecture/OrderingTest.php
+++ b/tests/Architecture/OrderingTest.php
@@ -16,6 +16,7 @@ final class OrderingTest
             ->classes(
                 Selector::inNamespace('Combee\Core\Ordering'),
                 Selector::inNamespace('Doctrine\Common\Collections'),
+                Selector::inNamespace('Money'),
                 Selector::inNamespace('Ramsey\Uuid'),
             )
             ->because('Ordering should not depend on other modules')

--- a/tests/Architecture/ProductCatalogTest.php
+++ b/tests/Architecture/ProductCatalogTest.php
@@ -17,6 +17,7 @@ final class ProductCatalogTest
             ->classes(
                 Selector::inNamespace('Combee\Core\ProductCatalog'),
                 Selector::inNamespace('Doctrine\Common\Collections'),
+                Selector::inNamespace('Money'),
                 Selector::inNamespace('Ramsey\Uuid'),
             )
             ->because('Product catalog should not depend on other modules')

--- a/tests/Unit/Ordering/Command/Handler/AddProductToCartHandlerTest.php
+++ b/tests/Unit/Ordering/Command/Handler/AddProductToCartHandlerTest.php
@@ -12,6 +12,7 @@ use Combee\Ordering\Contract\Model\OrderContract;
 use Combee\Ordering\Contract\Model\OrderItemContract;
 use Combee\Ordering\Contract\Provider\ProductDataProviderContract;
 use Combee\Ordering\Contract\Storage\CartStorageContract;
+use Money\Money;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -43,6 +44,8 @@ final class AddProductToCartHandlerTest extends TestCase
 
         $productData = new class () implements ProductData {
             public string $sku { get => 'OMG'; }
+
+            public Money $price { get => Money::PLN(100); }
         };
 
         $this->productDataProvider->method('getProductData')->willReturn($productData);

--- a/tests/Unit/ProductCatalog/Model/ProductTest.php
+++ b/tests/Unit/ProductCatalog/Model/ProductTest.php
@@ -1,8 +1,13 @@
-<?php declare(strict_types=1);
+<?php /** @noinspection PhpObjectFieldsAreOnlyWrittenInspection */
+
+declare(strict_types=1);
 
 namespace Tests\Unit\ProductCatalog\Model;
 
+use Combee\ProductCatalog\Model\Exception\NegativeOrZeroPriceException;
 use Combee\ProductCatalog\Model\Product;
+use Money\Money;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -12,8 +17,38 @@ final class ProductTest extends TestCase
     #[Test]
     public function it_can_be_created(): void
     {
-        $product = new Product(Uuid::uuid4(), 'OMG');
+        $product = new Product(Uuid::uuid4(), 'OMG', Money::PLN(150));
 
         $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    #[DataProvider('provideInvalidPrices')]
+    public function it_prevents_from_creating_product_with_invalid_price(Money $price): void
+    {
+        $this->expectException(NegativeOrZeroPriceException::class);
+        $this->expectExceptionMessage('Price must be greater than zero.');
+
+        $product = new Product(Uuid::uuid4(), 'OMG', $price);
+    }
+
+    #[Test]
+    #[DataProvider('provideInvalidPrices')]
+    public function it_prevents_changing_the_price_to_invalid_one(Money $price): void
+    {
+        $this->expectException(NegativeOrZeroPriceException::class);
+        $this->expectExceptionMessage('Price must be greater than zero.');
+
+        $product = new Product(Uuid::uuid4(), 'OMG', Money::PLN(150));
+        $product->price = $price;
+    }
+
+    /**
+     * @return iterable<array<Money>>
+     */
+    public static function provideInvalidPrices(): iterable
+    {
+        yield [Money::PLN(0)];
+        yield [Money::PLN(-1)];
     }
 }


### PR DESCRIPTION
- Added `moneyphp/money` as a new dependency for handling monetary values.
- Updated `Product` and related interfaces to incorporate the `price` property.
- Introduced `NegativeOrZeroPriceException` to enforce validation rules for product prices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added monetary pricing across product APIs; products now carry a price and examples include sample prices.
  - Validation ensures prices must be positive; clear error when zero or negative.

- Chores
  - Added Money library dependency.
  - Extended code style/tooling to include tests and CI task orchestration.

- Tests
  - Added unit tests for price validation and updated tests to include pricing.
  - Relaxed architecture rules to permit the Money dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->