### PR TITLE
:fire: Replace Ramsey UUID with custom identifier implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
   ],
   "require": {
     "php": "^8.4",
-    "ramsey/uuid": "^4.9",
     "doctrine/collections": "^2.3",
-    "moneyphp/money": "^4.7"
+    "moneyphp/money": "^4.7",
+    "symfony/uid": "^5.4 || ^6.4 || ^7.3"
   },
   "scripts": {
     "post-update-cmd": [

--- a/src/Core/Exception/LogicException.php
+++ b/src/Core/Exception/LogicException.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Exception;
+
+class LogicException extends \LogicException
+{
+}

--- a/src/Core/Model/Identifier/AbstractIdentifier.php
+++ b/src/Core/Model/Identifier/AbstractIdentifier.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Model\Identifier;
+
+use Symfony\Component\Uid\UuidV7;
+
+abstract class AbstractIdentifier extends UuidV7
+{
+    public static function new(): static
+    {
+        /** @phpstan-ignore new.static */
+        return new static();
+    }
+}

--- a/src/Core/Model/Identifier/OrderIdentifier.php
+++ b/src/Core/Model/Identifier/OrderIdentifier.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Model\Identifier;
+
+class OrderIdentifier extends AbstractIdentifier
+{
+}

--- a/src/Core/Model/Identifier/OrderItemIdentifier.php
+++ b/src/Core/Model/Identifier/OrderItemIdentifier.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Model\Identifier;
+
+class OrderItemIdentifier extends AbstractIdentifier
+{
+}

--- a/src/Core/Model/Identifier/ProductIdentifier.php
+++ b/src/Core/Model/Identifier/ProductIdentifier.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Model\Identifier;
+
+class ProductIdentifier extends AbstractIdentifier
+{
+}

--- a/src/Ordering/Application/Command/AddProductToCart.php
+++ b/src/Ordering/Application/Command/AddProductToCart.php
@@ -2,10 +2,10 @@
 
 namespace Combee\Ordering\Application\Command;
 
+use Combee\Core\Model\Identifier\OrderIdentifier;
 use Combee\Ordering\Contract\Command\AddProductToCartContract;
 use Combee\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Ordering\Model\AddItemStrategy\MergeSameSkuItemsStrategy;
-use Ramsey\Uuid\UuidInterface;
 
 readonly class AddProductToCart implements AddProductToCartContract
 {
@@ -13,7 +13,7 @@ readonly class AddProductToCart implements AddProductToCartContract
      * @param class-string<AddItemStrategyContract> $strategy
      */
     public function __construct(
-        public UuidInterface $cartUuid,
+        public OrderIdentifier $cartUuid,
         public string $sku,
         /** @var positive-int */
         public int $quantity,

--- a/src/Ordering/Application/Command/Handler/Exception/CartNotFoundException.php
+++ b/src/Ordering/Application/Command/Handler/Exception/CartNotFoundException.php
@@ -2,14 +2,14 @@
 
 namespace Combee\Ordering\Application\Command\Handler\Exception;
 
-use Ramsey\Uuid\UuidInterface;
+use Combee\Core\Model\Identifier\OrderIdentifier;
 
 class CartNotFoundException extends \InvalidArgumentException
 {
     /**
      * @phpstan-assert !null $value
      */
-    public static function throwIfNull(mixed $value, UuidInterface $cartUuid): void
+    public static function throwIfNull(mixed $value, OrderIdentifier $cartUuid): void
     {
         if ($value === null) {
             throw new self(

--- a/src/Ordering/Contract/Command/AddProductToCartContract.php
+++ b/src/Ordering/Contract/Command/AddProductToCartContract.php
@@ -2,12 +2,12 @@
 
 namespace Combee\Ordering\Contract\Command;
 
+use Combee\Core\Model\Identifier\OrderIdentifier;
 use Combee\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
-use Ramsey\Uuid\UuidInterface;
 
 interface AddProductToCartContract
 {
-    public UuidInterface $cartUuid { get; }
+    public OrderIdentifier $cartUuid { get; }
 
     public string $sku { get; }
 

--- a/src/Ordering/Contract/Model/OrderContract.php
+++ b/src/Ordering/Contract/Model/OrderContract.php
@@ -2,13 +2,13 @@
 
 namespace Combee\Ordering\Contract\Model;
 
+use Combee\Core\Model\Identifier\OrderIdentifier;
 use Combee\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Doctrine\Common\Collections\Collection;
-use Ramsey\Uuid\UuidInterface;
 
 interface OrderContract
 {
-    public UuidInterface $uuid { get; }
+    public OrderIdentifier $uuid { get; }
 
     /** @var Collection<array-key, OrderItemContract> */
     public Collection $items { get; }

--- a/src/Ordering/Contract/Model/OrderItemContract.php
+++ b/src/Ordering/Contract/Model/OrderItemContract.php
@@ -2,11 +2,11 @@
 
 namespace Combee\Ordering\Contract\Model;
 
-use Ramsey\Uuid\UuidInterface;
+use Combee\Core\Model\Identifier\OrderItemIdentifier;
 
 interface OrderItemContract
 {
-    public UuidInterface $uuid { get; }
+    public OrderItemIdentifier $uuid { get; }
 
     public string $productSku { get; }
 

--- a/src/Ordering/Contract/Storage/CartStorageContract.php
+++ b/src/Ordering/Contract/Storage/CartStorageContract.php
@@ -2,12 +2,12 @@
 
 namespace Combee\Ordering\Contract\Storage;
 
+use Combee\Core\Model\Identifier\OrderIdentifier;
 use Combee\Ordering\Contract\Model\OrderContract;
-use Ramsey\Uuid\UuidInterface;
 
 interface CartStorageContract
 {
-    public function get(UuidInterface $cartUuid): ?OrderContract;
+    public function get(OrderIdentifier $cartUuid): ?OrderContract;
 
     public function save(OrderContract $cart): void;
 }

--- a/src/Ordering/Model/Order.php
+++ b/src/Ordering/Model/Order.php
@@ -2,12 +2,12 @@
 
 namespace Combee\Ordering\Model;
 
+use Combee\Core\Model\Identifier\OrderIdentifier;
 use Combee\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Ordering\Contract\Model\Exception\OrderSealedException;
 use Combee\Ordering\Contract\Model\OrderContract;
 use Combee\Ordering\Contract\Model\OrderItemContract;
 use Doctrine\Common\Collections\Collection;
-use Ramsey\Uuid\UuidInterface;
 
 class Order implements OrderContract
 {
@@ -15,7 +15,7 @@ class Order implements OrderContract
      * @param Collection<array-key, OrderItemContract> $items
      */
     public function __construct(
-        public readonly UuidInterface $uuid,
+        public readonly OrderIdentifier $uuid,
         public Collection $items {
             get => $this->items;
         },

--- a/src/Ordering/Model/OrderItem.php
+++ b/src/Ordering/Model/OrderItem.php
@@ -2,14 +2,14 @@
 
 namespace Combee\Ordering\Model;
 
+use Combee\Core\Model\Identifier\OrderItemIdentifier;
 use Combee\Ordering\Contract\Model\OrderItemContract;
 use Combee\Ordering\Model\Exception\NegativeOrZeroQuantityException;
-use Ramsey\Uuid\UuidInterface;
 
 class OrderItem implements OrderItemContract
 {
     public function __construct(
-        public readonly UuidInterface $uuid,
+        public readonly OrderItemIdentifier $uuid,
         public readonly string $productSku,
         public int $quantity {
             get {

--- a/src/ProductCatalog/Contract/Model/ProductContract.php
+++ b/src/ProductCatalog/Contract/Model/ProductContract.php
@@ -3,8 +3,14 @@
 namespace Combee\ProductCatalog\Contract\Model;
 
 use Combee\Core\Contract\Priceable;
+use Combee\Core\Model\Identifier\ProductIdentifier;
+use Money\Money;
 
 interface ProductContract extends Priceable
 {
+    public ProductIdentifier $uuid { get; }
+
     public string $sku { get; }
+
+    public Money $price { get; set; }
 }

--- a/src/ProductCatalog/Model/Exception/NegativeOrZeroPriceException.php
+++ b/src/ProductCatalog/Model/Exception/NegativeOrZeroPriceException.php
@@ -2,9 +2,10 @@
 
 namespace Combee\ProductCatalog\Model\Exception;
 
+use Combee\Core\Exception\LogicException;
 use Money\Money;
 
-class NegativeOrZeroPriceException extends \LogicException
+class NegativeOrZeroPriceException extends LogicException
 {
     public static function throwIfNotPositive(Money $value): void
     {

--- a/src/ProductCatalog/Model/Product.php
+++ b/src/ProductCatalog/Model/Product.php
@@ -2,15 +2,15 @@
 
 namespace Combee\ProductCatalog\Model;
 
+use Combee\Core\Model\Identifier\ProductIdentifier;
 use Combee\ProductCatalog\Contract\Model\ProductContract;
 use Combee\ProductCatalog\Model\Exception\NegativeOrZeroPriceException;
 use Money\Money;
-use Ramsey\Uuid\UuidInterface;
 
 class Product implements ProductContract
 {
     public function __construct(
-        public readonly UuidInterface $uuid,
+        public readonly ProductIdentifier $uuid,
         public readonly string $sku,
         public Money $price {
             get => $this->price;

--- a/tests/Architecture/OrderingTest.php
+++ b/tests/Architecture/OrderingTest.php
@@ -11,13 +11,13 @@ final class OrderingTest
     public function test_ordering_depends_only_on_its_own_classes(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Combee\Core\Ordering'))
+            ->classes(Selector::inNamespace('Combee\Ordering'))
             ->canOnlyDependOn()
             ->classes(
-                Selector::inNamespace('Combee\Core\Ordering'),
+                Selector::inNamespace('Combee\Core'),
+                Selector::inNamespace('Combee\Ordering'),
                 Selector::inNamespace('Doctrine\Common\Collections'),
                 Selector::inNamespace('Money'),
-                Selector::inNamespace('Ramsey\Uuid'),
             )
             ->because('Ordering should not depend on other modules')
         ;

--- a/tests/Architecture/ProductCatalogTest.php
+++ b/tests/Architecture/ProductCatalogTest.php
@@ -11,14 +11,14 @@ final class ProductCatalogTest
     public function test_product_catalog_depends_only_on_its_own_classes(): Rule
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Combee\Core\ProductCatalog'))
-            ->excluding(Selector::inNamespace('Combee\Core\ProductCatalog\Integration'))
+            ->classes(Selector::inNamespace('Combee\ProductCatalog'))
+            ->excluding(Selector::inNamespace('Combee\ProductCatalog\Integration'))
             ->canOnlyDependOn()
             ->classes(
-                Selector::inNamespace('Combee\Core\ProductCatalog'),
+                Selector::inNamespace('Combee\Core'),
+                Selector::inNamespace('Combee\ProductCatalog'),
                 Selector::inNamespace('Doctrine\Common\Collections'),
                 Selector::inNamespace('Money'),
-                Selector::inNamespace('Ramsey\Uuid'),
             )
             ->because('Product catalog should not depend on other modules')
         ;
@@ -30,20 +30,20 @@ final class ProductCatalogTest
     public function test_ordering_integration_depends_only_on_product_catalog_and_ordering_contracts(): iterable
     {
         yield PHPat::rule()
-            ->classes(Selector::inNamespace('Combee\Core\ProductCatalog\Integration\Ordering'))
+            ->classes(Selector::inNamespace('Combee\ProductCatalog\Integration\Ordering'))
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Combee\Core\ProductCatalog\Integration'))
-            ->excluding(Selector::inNamespace('Combee\Core\ProductCatalog\Integration\Ordering'))
+            ->classes(Selector::inNamespace('Combee\ProductCatalog\Integration'))
+            ->excluding(Selector::inNamespace('Combee\ProductCatalog\Integration\Ordering'))
             ->because('Ordering integration should not depend on other integration modules')
         ;
 
         yield PHPat::rule()
-            ->classes(Selector::inNamespace('Combee\Core\ProductCatalog\Integration\Ordering'))
+            ->classes(Selector::inNamespace('Combee\ProductCatalog\Integration\Ordering'))
             ->canOnlyDependOn()
             ->classes(
-                Selector::inNamespace('Combee\Core\Ordering\Contract'),
-                Selector::inNamespace('Combee\Core\ProductCatalog'),
-                Selector::inNamespace('Combee\Core\ProductCatalog\Integration\Ordering'),
+                Selector::inNamespace('Combee\Ordering\Contract'),
+                Selector::inNamespace('Combee\ProductCatalog'),
+                Selector::inNamespace('Combee\ProductCatalog\Integration\Ordering'),
             )
             ->because('Product catalog should not depend on other layers than their own classes and known contracts')
         ;

--- a/tests/Helper/MotherObject/OrderItemMother.php
+++ b/tests/Helper/MotherObject/OrderItemMother.php
@@ -2,14 +2,14 @@
 
 namespace Tests\Helper\MotherObject;
 
+use Combee\Core\Model\Identifier\OrderItemIdentifier;
+use Combee\Ordering\Contract\Model\OrderItemContract;
 use Combee\Ordering\Model\OrderItem;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
 
 class OrderItemMother
 {
-    public static function some(?UuidInterface $uuid = null, string $productSku = 'OMG', int $quantity = 1): OrderItem
+    public static function some(?OrderItemIdentifier $uuid = null, string $productSku = 'OMG', int $quantity = 1): OrderItemContract
     {
-        return new OrderItem($uuid ?? Uuid::uuid4(), $productSku, $quantity);
+        return new OrderItem($uuid ?? OrderItemIdentifier::new(), $productSku, $quantity);
     }
 }

--- a/tests/Helper/MotherObject/OrderMother.php
+++ b/tests/Helper/MotherObject/OrderMother.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Helper\MotherObject;
+
+use Combee\Core\Model\Identifier\OrderIdentifier;
+use Combee\Ordering\Contract\Model\OrderContract;
+use Combee\Ordering\Contract\Model\OrderItemContract;
+use Combee\Ordering\Model\Order;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class OrderMother
+{
+    /**
+     * @param Collection<array-key, OrderItemContract>|null $items
+     */
+    public static function some(?OrderIdentifier $uuid = null, ?Collection $items = null, string $state = 'cart'): OrderContract
+    {
+        return new Order(
+            $uuid ?? OrderIdentifier::new(),
+            $items ?? new ArrayCollection(),
+            $state,
+        );
+    }
+}

--- a/tests/Helper/MotherObject/ProductMother.php
+++ b/tests/Helper/MotherObject/ProductMother.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Helper\MotherObject;
+
+use Combee\Core\Model\Identifier\ProductIdentifier;
+use Combee\ProductCatalog\Contract\Model\ProductContract;
+use Combee\ProductCatalog\Model\Product;
+use Money\Money;
+
+class ProductMother
+{
+    public static function some(?ProductIdentifier $uuid = null, string $sku = 'OMG', ?Money $price = null): ProductContract
+    {
+        return new Product(
+            $uuid ?? ProductIdentifier::new(),
+            $sku,
+            $price ?? Money::PLN(150),
+        );
+    }
+}

--- a/tests/Unit/Ordering/Application/Command/Handler/AddProductToCartHandlerTest.php
+++ b/tests/Unit/Ordering/Application/Command/Handler/AddProductToCartHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Ordering\Application\Command\Handler;
 
+use Combee\Core\Model\Identifier\OrderIdentifier;
 use Combee\Ordering\Application\Command\AddProductToCart;
 use Combee\Ordering\Application\Command\Handler\AddProductToCartHandler;
 use Combee\Ordering\Application\Command\Handler\Exception\ProductNotFoundException;
@@ -16,7 +17,6 @@ use Money\Money;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
 
 final class AddProductToCartHandlerTest extends TestCase
 {
@@ -36,7 +36,7 @@ final class AddProductToCartHandlerTest extends TestCase
     #[Test]
     public function it_adds_product_to_cart(): void
     {
-        $command = new AddProductToCart($cartUuid = Uuid::uuid4(), 'OMG', 2);
+        $command = new AddProductToCart($cartUuid = OrderIdentifier::new(), 'OMG', 2);
 
         $cart = $this->createMock(OrderContract::class);
 
@@ -64,7 +64,7 @@ final class AddProductToCartHandlerTest extends TestCase
     #[Test]
     public function it_throws_exception_if_cart_not_found(): void
     {
-        $command = new AddProductToCart($cartUuid = Uuid::uuid4(), 'OMG', 2);
+        $command = new AddProductToCart($cartUuid = OrderIdentifier::new(), 'OMG', 2);
 
         $this->cartStorage->method('get')->with($cartUuid)->willReturn(null);
 
@@ -79,7 +79,7 @@ final class AddProductToCartHandlerTest extends TestCase
     #[Test]
     public function it_throws_exception_if_product_not_found(): void
     {
-        $command = new AddProductToCart($cartUuid = Uuid::uuid4(), 'OMG', 2);
+        $command = new AddProductToCart($cartUuid = OrderIdentifier::new(), 'OMG', 2);
 
         $cart = $this->createMock(OrderContract::class);
 

--- a/tests/Unit/Ordering/Model/OrderItemTest.php
+++ b/tests/Unit/Ordering/Model/OrderItemTest.php
@@ -3,18 +3,17 @@
 namespace Tests\Unit\Ordering\Model;
 
 use Combee\Ordering\Model\Exception\NegativeOrZeroQuantityException;
-use Combee\Ordering\Model\OrderItem;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
+use Tests\Helper\MotherObject\OrderItemMother;
 
 final class OrderItemTest extends TestCase
 {
     #[Test]
     public function it_can_be_created(): void
     {
-        $item = new OrderItem(Uuid::uuid4(), 'OMG', 1);
+        $item = OrderItemMother::some();
 
         $this->expectNotToPerformAssertions();
     }
@@ -26,7 +25,7 @@ final class OrderItemTest extends TestCase
         $this->expectException(NegativeOrZeroQuantityException::class);
         $this->expectExceptionMessage('Quantity must be greater than zero.');
 
-        $item = new OrderItem(Uuid::uuid4(), 'OMG', $quantity);
+        $item = OrderItemMother::some(quantity: $quantity);
     }
 
     /**

--- a/tests/Unit/Ordering/Model/OrderTest.php
+++ b/tests/Unit/Ordering/Model/OrderTest.php
@@ -5,19 +5,18 @@ namespace Tests\Unit\Ordering\Model;
 use Combee\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Ordering\Contract\Model\Exception\OrderSealedException;
 use Combee\Ordering\Contract\Model\OrderItemContract;
-use Combee\Ordering\Model\Order;
-use Combee\Ordering\Model\OrderItem;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
+use Tests\Helper\MotherObject\OrderItemMother;
+use Tests\Helper\MotherObject\OrderMother;
 
 final class OrderTest extends TestCase
 {
     #[Test]
     public function it_can_be_created(): void
     {
-        $order = new Order(Uuid::uuid4(), new ArrayCollection());
+        $order = OrderMother::some();
 
         $this->expectNotToPerformAssertions();
     }
@@ -26,9 +25,9 @@ final class OrderTest extends TestCase
     public function it_can_be_created_with_items(): void
     {
         /** @var ArrayCollection<array-key, OrderItemContract> $items */
-        $items = new ArrayCollection([new OrderItem(Uuid::uuid4(), 'OMG', 1), new OrderItem(Uuid::uuid4(), 'LOL', 1)]);
+        $items = new ArrayCollection([OrderItemMother::some(productSku: 'OMGG'), OrderItemMother::some(productSku: 'LOL')]);
 
-        $order = new Order(Uuid::uuid4(), $items);
+        $order = OrderMother::some(items: $items);
 
         $this->assertSame($items, $order->items);
     }
@@ -36,7 +35,7 @@ final class OrderTest extends TestCase
     #[Test]
     public function it_allows_to_add_items_using_strategy(): void
     {
-        $order = new Order(Uuid::uuid4(), $items = new ArrayCollection());
+        $order = OrderMother::some(items: $items = new ArrayCollection());
 
         $orderItem = $this->createMock(OrderItemContract::class);
 
@@ -54,7 +53,7 @@ final class OrderTest extends TestCase
 
         $orderItem = $this->createMock(OrderItemContract::class);
 
-        new Order(Uuid::uuid4(), new ArrayCollection(), state: 'placed')->addItem(
+        OrderMother::some(state: 'placed')->addItem(
             $orderItem,
             $this->createMock(AddItemStrategyContract::class),
         );

--- a/tests/Unit/ProductCatalog/Model/ProductTest.php
+++ b/tests/Unit/ProductCatalog/Model/ProductTest.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Tests\Unit\ProductCatalog\Model;
 
 use Combee\ProductCatalog\Model\Exception\NegativeOrZeroPriceException;
-use Combee\ProductCatalog\Model\Product;
 use Money\Money;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Ramsey\Uuid\Uuid;
+use Tests\Helper\MotherObject\ProductMother;
 
 final class ProductTest extends TestCase
 {
     #[Test]
     public function it_can_be_created(): void
     {
-        $product = new Product(Uuid::uuid4(), 'OMG', Money::PLN(150));
+        $product = ProductMother::some();
 
         $this->expectNotToPerformAssertions();
     }
@@ -29,7 +28,7 @@ final class ProductTest extends TestCase
         $this->expectException(NegativeOrZeroPriceException::class);
         $this->expectExceptionMessage('Price must be greater than zero.');
 
-        $product = new Product(Uuid::uuid4(), 'OMG', $price);
+        $product = ProductMother::some(price: $price);
     }
 
     #[Test]
@@ -39,7 +38,7 @@ final class ProductTest extends TestCase
         $this->expectException(NegativeOrZeroPriceException::class);
         $this->expectExceptionMessage('Price must be greater than zero.');
 
-        $product = new Product(Uuid::uuid4(), 'OMG', Money::PLN(150));
+        $product = ProductMother::some();
         $product->price = $price;
     }
 


### PR DESCRIPTION
- Removed `ramsey/uuid` dependency and introduced custom identifier classes (`AbstractIdentifier`, `ProductIdentifier`, `OrderIdentifier`, `OrderItemIdentifier`) for UUID handling.
- Updated all model and contract classes to use the new identifier implementations (`Product`, `Order`, `OrderItem`, and respective contract classes).
- Introduced tailored UUID generation and validation logic in `AbstractIdentifier`.
- Adjusted tests to use helper `MotherObject` classes for consistent model instantiation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Product now exposes a price field (Money) with validations.
  - Added domain-specific identifiers for orders, order items, and products with built-in generation.

- Refactor
  - Replaced external UUID types with internal identifier types across models, contracts, commands and exceptions.
  - Standardized use of a custom LogicException.

- Chores
  - Removed ramsey/uuid dependency; added symfony/uid support.

- Tests
  - Updated architecture rules and switched tests to reusable "mother" helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->