### PR TITLE
:truck: Replace `Doctrine\Common\Collections` with custom abstraction

### DIFF
--- a/src/Core/Ordering/Contract/Model/AddItemStrategy/AddItemStrategyContract.php
+++ b/src/Core/Ordering/Contract/Model/AddItemStrategy/AddItemStrategyContract.php
@@ -3,7 +3,7 @@
 namespace Combee\Core\Ordering\Contract\Model\AddItemStrategy;
 
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
-use Doctrine\Common\Collections\Collection;
+use Combee\Core\Shared\Contract\Collection;
 
 interface AddItemStrategyContract
 {

--- a/src/Core/Ordering/Contract/Model/OrderContract.php
+++ b/src/Core/Ordering/Contract/Model/OrderContract.php
@@ -3,8 +3,8 @@
 namespace Combee\Core\Ordering\Contract\Model;
 
 use Combee\Core\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
+use Combee\Core\Shared\Contract\Collection;
 use Combee\Core\Shared\Model\Identifier\OrderIdentifier;
-use Doctrine\Common\Collections\Collection;
 
 interface OrderContract
 {

--- a/src/Core/Ordering/Model/AddItemStrategy/AddAsNewItemStrategy.php
+++ b/src/Core/Ordering/Model/AddItemStrategy/AddAsNewItemStrategy.php
@@ -4,7 +4,7 @@ namespace Combee\Core\Ordering\Model\AddItemStrategy;
 
 use Combee\Core\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
-use Doctrine\Common\Collections\Collection;
+use Combee\Core\Shared\Contract\Collection;
 
 final readonly class AddAsNewItemStrategy implements AddItemStrategyContract
 {

--- a/src/Core/Ordering/Model/AddItemStrategy/MergeSameSkuItemsStrategy.php
+++ b/src/Core/Ordering/Model/AddItemStrategy/MergeSameSkuItemsStrategy.php
@@ -4,7 +4,7 @@ namespace Combee\Core\Ordering\Model\AddItemStrategy;
 
 use Combee\Core\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
-use Doctrine\Common\Collections\Collection;
+use Combee\Core\Shared\Contract\Collection;
 
 final readonly class MergeSameSkuItemsStrategy implements AddItemStrategyContract
 {

--- a/src/Core/Ordering/Model/Order.php
+++ b/src/Core/Ordering/Model/Order.php
@@ -6,8 +6,8 @@ use Combee\Core\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Core\Ordering\Contract\Model\Exception\OrderSealedException;
 use Combee\Core\Ordering\Contract\Model\OrderContract;
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
+use Combee\Core\Shared\Contract\Collection;
 use Combee\Core\Shared\Model\Identifier\OrderIdentifier;
-use Doctrine\Common\Collections\Collection;
 
 class Order implements OrderContract
 {

--- a/src/Core/Shared/Collection/AbstractLazyCollection.php
+++ b/src/Core/Shared/Collection/AbstractLazyCollection.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Shared\Collection;
+
+use Combee\Core\Shared\Contract\Collection;
+use Doctrine\Common\Collections\AbstractLazyCollection as DoctrineAbstractLazyCollection;
+
+/**
+ * Lazy collection that is backed by a concrete collection
+ *
+ * @phpstan-template TKey of array-key
+ * @phpstan-template T
+ * @template-extends DoctrineAbstractLazyCollection<TKey,T>
+ * @template-implements Collection<TKey,T>
+ */
+abstract class AbstractLazyCollection extends DoctrineAbstractLazyCollection implements Collection
+{
+}

--- a/src/Core/Shared/Collection/ArrayCollection.php
+++ b/src/Core/Shared/Collection/ArrayCollection.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Shared\Collection;
+
+use Combee\Core\Shared\Contract\Collection;
+use Doctrine\Common\Collections\ArrayCollection as DoctrineArrayCollection;
+
+/**
+ * @phpstan-template TKey of array-key
+ * @phpstan-template T
+ * @template-extends DoctrineArrayCollection<TKey,T>
+ * @template-implements Collection<TKey,T>
+ * @phpstan-consistent-constructor
+ */
+class ArrayCollection extends DoctrineArrayCollection implements Collection
+{
+}

--- a/src/Core/Shared/Contract/Collection.php
+++ b/src/Core/Shared/Contract/Collection.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Shared\Contract;
+
+use Doctrine\Common\Collections\Collection as DoctrineCollection;
+
+/**
+ * @phpstan-template TKey of array-key
+ * @phpstan-template T
+ *
+ * @template-extends DoctrineCollection<TKey, T>
+ */
+interface Collection extends DoctrineCollection
+{
+}

--- a/src/Core/Shared/Exception/Exception.php
+++ b/src/Core/Shared/Exception/Exception.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Shared\Exception;
+
+class Exception extends \Exception
+{
+}

--- a/tests/Architecture/OrderingTest.php
+++ b/tests/Architecture/OrderingTest.php
@@ -16,7 +16,6 @@ final class OrderingTest
             ->classes(
                 Selector::inNamespace('Combee\Core\Ordering'),
                 Selector::inNamespace('Combee\Core\Shared'),
-                Selector::inNamespace('Doctrine\Common\Collections'),
             )
             ->because('Ordering should not depend on other modules')
         ;

--- a/tests/Architecture/ProductCatalogTest.php
+++ b/tests/Architecture/ProductCatalogTest.php
@@ -17,7 +17,6 @@ final class ProductCatalogTest
             ->classes(
                 Selector::inNamespace('Combee\Core\ProductCatalog'),
                 Selector::inNamespace('Combee\Core\Shared'),
-                Selector::inNamespace('Doctrine\Common\Collections'),
             )
             ->because('Product catalog should not depend on other modules')
         ;

--- a/tests/Helper/MotherObject/OrderMother.php
+++ b/tests/Helper/MotherObject/OrderMother.php
@@ -5,9 +5,9 @@ namespace Tests\Helper\MotherObject;
 use Combee\Core\Ordering\Contract\Model\OrderContract;
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
 use Combee\Core\Ordering\Model\Order;
+use Combee\Core\Shared\Collection\ArrayCollection;
+use Combee\Core\Shared\Contract\Collection;
 use Combee\Core\Shared\Model\Identifier\OrderIdentifier;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 
 class OrderMother
 {

--- a/tests/Unit/Core/Ordering/Model/AddItemStrategy/AddAsNewItemStrategyTest.php
+++ b/tests/Unit/Core/Ordering/Model/AddItemStrategy/AddAsNewItemStrategyTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Core\Ordering\Model\AddItemStrategy;
 
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
 use Combee\Core\Ordering\Model\AddItemStrategy\AddAsNewItemStrategy;
-use Doctrine\Common\Collections\ArrayCollection;
+use Combee\Core\Shared\Collection\ArrayCollection;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tests\Helper\MotherObject\OrderItemMother;

--- a/tests/Unit/Core/Ordering/Model/AddItemStrategy/MergeSameSkuItemsStrategyTest.php
+++ b/tests/Unit/Core/Ordering/Model/AddItemStrategy/MergeSameSkuItemsStrategyTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Core\Ordering\Model\AddItemStrategy;
 
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
 use Combee\Core\Ordering\Model\AddItemStrategy\MergeSameSkuItemsStrategy;
-use Doctrine\Common\Collections\ArrayCollection;
+use Combee\Core\Shared\Collection\ArrayCollection;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tests\Helper\MotherObject\OrderItemMother;

--- a/tests/Unit/Core/Ordering/Model/OrderTest.php
+++ b/tests/Unit/Core/Ordering/Model/OrderTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Core\Ordering\Model;
 use Combee\Core\Ordering\Contract\Model\AddItemStrategy\AddItemStrategyContract;
 use Combee\Core\Ordering\Contract\Model\Exception\OrderSealedException;
 use Combee\Core\Ordering\Contract\Model\OrderItemContract;
-use Doctrine\Common\Collections\ArrayCollection;
+use Combee\Core\Shared\Collection\ArrayCollection;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Tests\Helper\MotherObject\OrderItemMother;


### PR DESCRIPTION
- Introduced `Collection` interface and corresponding implementations (`ArrayCollection`, `AbstractLazyCollection`) under `Shared\Contract` and `Shared\Collection` namespaces.
- Updated all references in `Ordering` and test classes to use the new `Collection` abstraction.
- Removed dependency on `Doctrine\Common\Collections` from `Ordering` and updated architecture rules to enforce module independence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a shared collection interface with concrete collection implementations for consistent behavior across modules.
  - Added a base exception type for shared use.

- Refactor
  - Replaced third‑party collection types in ordering with the new shared collection across contracts, models, and strategies.
  - Aligned order item collections to the shared contract.

- Tests
  - Tightened architectural rules to limit external dependencies.
  - Updated unit tests to use the shared collection implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->