### PR TITLE
:sparkles: Introduce a basic pricing calculation system

### DIFF
--- a/src/Core/Ordering/Contract/Provider/PriceProviderContract.php
+++ b/src/Core/Ordering/Contract/Provider/PriceProviderContract.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Ordering\Contract\Provider;
+
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Price;
+
+interface PriceProviderContract
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function providePriceFor(Priceable $priceable, array $context = []): Price;
+}

--- a/src/Core/Pricing/Calculator/AggregateCalculator.php
+++ b/src/Core/Pricing/Calculator/AggregateCalculator.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Pricing\Calculator;
+
+use Combee\Core\Pricing\Contract\CalculatorContract;
+use Combee\Core\Pricing\Contract\Exception\NoSupportedCalculatorException;
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Price;
+use Combee\Core\Shared\Exception\InvalidArgumentException;
+
+final readonly class AggregateCalculator implements CalculatorContract
+{
+    /** @var iterable<CalculatorContract> */
+    private iterable $calculators;
+
+    /**
+     * @param iterable<CalculatorContract|mixed> $calculators
+     */
+    public function __construct(
+        iterable $calculators,
+    ) {
+        $this->calculators = $calculators instanceof \Traversable ? iterator_to_array($calculators) : $calculators;
+
+        foreach ($this->calculators as $calculator) {
+            if (!$calculator instanceof CalculatorContract) {
+                throw new InvalidArgumentException(sprintf('Calculator must implement "%s".', CalculatorContract::class));
+            }
+        }
+    }
+
+    /**
+     * @throws NoSupportedCalculatorException
+     */
+    public function calculate(Priceable $priceable, array $context = []): Price
+    {
+        foreach ($this->calculators as $calculator) {
+            if (!$calculator->supports($priceable, $context)) {
+                continue;
+            }
+
+            return $calculator->calculate($priceable, $context);
+        }
+
+        NoSupportedCalculatorException::throw();
+    }
+
+    public function supports(Priceable $priceable, array $context = []): bool
+    {
+        return true;
+    }
+}

--- a/src/Core/Pricing/Calculator/DefaultCalculator.php
+++ b/src/Core/Pricing/Calculator/DefaultCalculator.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Pricing\Calculator;
+
+use Combee\Core\Pricing\Contract\CalculatorContract;
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Price;
+
+final readonly class DefaultCalculator implements CalculatorContract
+{
+    public function calculate(Priceable $priceable, array $context = []): Price
+    {
+        return $priceable->price;
+    }
+
+    public function supports(Priceable $priceable, array $context = []): bool
+    {
+        return true;
+    }
+}

--- a/src/Core/Pricing/Contract/CalculatorContract.php
+++ b/src/Core/Pricing/Contract/CalculatorContract.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Pricing\Contract;
+
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Price;
+
+interface CalculatorContract
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function calculate(Priceable $priceable, array $context = []): Price;
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function supports(Priceable $priceable, array $context = []): bool;
+}

--- a/src/Core/Pricing/Contract/Exception/NoSupportedCalculatorException.php
+++ b/src/Core/Pricing/Contract/Exception/NoSupportedCalculatorException.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Pricing\Contract\Exception;
+
+use Combee\Core\Shared\Exception\Exception;
+
+class NoSupportedCalculatorException extends Exception
+{
+    /**
+     * @throws NoSupportedCalculatorException
+     */
+    public static function throw(): never
+    {
+        throw new self('No supported calculator found.');
+    }
+}

--- a/src/Core/Pricing/Integration/Ordering/PriceProvider.php
+++ b/src/Core/Pricing/Integration/Ordering/PriceProvider.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Pricing\Integration\Ordering;
+
+use Combee\Core\Ordering\Contract\Provider\PriceProviderContract;
+use Combee\Core\Pricing\Contract\CalculatorContract;
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Price;
+
+final readonly class PriceProvider implements PriceProviderContract
+{
+    public function __construct(
+        private CalculatorContract $calculator,
+    ) {
+    }
+
+    /** @inheritDoc */
+    public function providePriceFor(Priceable $priceable, array $context = []): Price
+    {
+        return $this->calculator->calculate($priceable, $context);
+    }
+}

--- a/src/Core/Shared/Exception/Exception.php
+++ b/src/Core/Shared/Exception/Exception.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Combee\Core\Shared\Exception;
+
+class Exception extends \Exception
+{
+}

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -25,7 +25,7 @@ tasks:
 
   infection:
     cmds:
-      - tools/bin/infection
+      - tools/bin/infection --min-msi=90 --min-covered-msi=90 --threads=max
     silent: true
 
   ci:

--- a/tests/Unit/Core/Pricing/Integration/Calculator/AggregateCalculatorTest.php
+++ b/tests/Unit/Core/Pricing/Integration/Calculator/AggregateCalculatorTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Core\Pricing\Integration\Calculator;
+
+use Combee\Core\Pricing\Calculator\AggregateCalculator;
+use Combee\Core\Pricing\Contract\CalculatorContract;
+use Combee\Core\Pricing\Contract\Exception\NoSupportedCalculatorException;
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Currency;
+use Combee\Core\Shared\DataObject\Price;
+use Combee\Core\Shared\Exception\InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class AggregateCalculatorTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_created(): void
+    {
+        $calculator = new AggregateCalculator([]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function it_can_be_created_with_calculators(): void
+    {
+        $calculator1 = $this->createMock(CalculatorContract::class);
+        $calculator2 = $this->createMock(CalculatorContract::class);
+
+        $aggregateCalculator = new AggregateCalculator([$calculator1, $calculator2]);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function it_throws_exception_if_calculator_does_not_implement_contract(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Calculator must implement "Combee\Core\Pricing\Contract\CalculatorContract".');
+
+        $invalidCalculator = new \stdClass();
+
+        new AggregateCalculator([$invalidCalculator]);
+    }
+
+    #[Test]
+    public function it_delegates_calculation_to_first_supporting_calculator(): void
+    {
+        $expectedPrice = new Price(1500, new Currency('EUR'));
+        $priceable = $this->createMock(Priceable::class);
+
+        $calculator1 = $this->createMock(CalculatorContract::class);
+        $calculator1->expects($this->once())
+            ->method('supports')
+            ->with($priceable, [])
+            ->willReturn(false);
+        $calculator1->expects($this->never())
+            ->method('calculate');
+
+        $calculator2 = $this->createMock(CalculatorContract::class);
+        $calculator2->expects($this->once())
+            ->method('supports')
+            ->with($priceable, [])
+            ->willReturn(true);
+        $calculator2->expects($this->once())
+            ->method('calculate')
+            ->with($priceable, [])
+            ->willReturn($expectedPrice);
+
+        $calculator3 = $this->createMock(CalculatorContract::class);
+        $calculator3->expects($this->never())
+            ->method('supports');
+        $calculator3->expects($this->never())
+            ->method('calculate');
+
+        $aggregateCalculator = new AggregateCalculator([$calculator1, $calculator2, $calculator3]);
+
+        $result = $aggregateCalculator->calculate($priceable);
+
+        $this->assertSame($expectedPrice, $result);
+    }
+
+    #[Test]
+    public function it_throws_exception_when_no_calculator_supports_priceable(): void
+    {
+        $this->expectException(NoSupportedCalculatorException::class);
+        $this->expectExceptionMessage('No supported calculator found.');
+
+        $priceable = $this->createMock(Priceable::class);
+
+        $calculator1 = $this->createMock(CalculatorContract::class);
+        $calculator1->method('supports')->willReturn(false);
+
+        $calculator2 = $this->createMock(CalculatorContract::class);
+        $calculator2->method('supports')->willReturn(false);
+
+        $aggregateCalculator = new AggregateCalculator([$calculator1, $calculator2]);
+
+        $aggregateCalculator->calculate($priceable);
+    }
+
+    #[Test]
+    public function it_throws_exception_when_no_calculators_provided(): void
+    {
+        $this->expectException(NoSupportedCalculatorException::class);
+        $this->expectExceptionMessage('No supported calculator found.');
+
+        $priceable = $this->createMock(Priceable::class);
+
+        $aggregateCalculator = new AggregateCalculator([]);
+
+        $aggregateCalculator->calculate($priceable);
+    }
+
+    #[Test]
+    public function it_always_supports_any_priceable(): void
+    {
+        $priceable = $this->createMock(Priceable::class);
+
+        $aggregateCalculator = new AggregateCalculator([]);
+
+        $this->assertTrue($aggregateCalculator->supports($priceable));
+    }
+}

--- a/tests/Unit/Core/Pricing/Integration/Calculator/DefaultCalculator.php
+++ b/tests/Unit/Core/Pricing/Integration/Calculator/DefaultCalculator.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Core\Pricing\Integration\Calculator;
+
+use Combee\Core\Pricing\Calculator\DefaultCalculator;
+use Combee\Core\Shared\Contract\Priceable;
+use Combee\Core\Shared\DataObject\Currency;
+use Combee\Core\Shared\DataObject\Price;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultCalculatorTest extends TestCase
+{
+    #[Test]
+    public function it_can_be_created(): void
+    {
+        $calculator = new DefaultCalculator();
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function it_returns_priceable_price(): void
+    {
+        $calculator = new DefaultCalculator();
+        $expectedPrice = new Price(1000, new Currency('EUR'));
+
+        $priceable = $this->createMock(Priceable::class);
+        $priceable->price = $expectedPrice;
+
+        $result = $calculator->calculate($priceable);
+
+        $this->assertSame($expectedPrice, $result);
+    }
+
+    #[Test]
+    public function it_always_supports_any_priceable(): void
+    {
+        $calculator = new DefaultCalculator();
+        $priceable = $this->createMock(Priceable::class);
+
+        $this->assertTrue($calculator->supports($priceable));
+    }
+}


### PR DESCRIPTION
- Added `PriceProviderContract` for price provision.
- Introduced `CalculatorContract` and two implementations: `DefaultCalculator` and `AggregateCalculator`.
- Implemented `PriceProvider` as an integration for pricing calculations, utilizing `CalculatorContract`.
- Added exception handling with `NoSupportedCalculatorException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces a unified pricing provider with pluggable calculators for flexible price computation.
  * Automatically selects the first applicable calculator and includes a default calculator for base prices.
  * Adds a dedicated error when no suitable calculator is found to improve reliability.
  * Provides an adapter to expose calculator-based pricing to ordering flows.

* **Tests**
  * Adds comprehensive unit tests covering calculator selection, default behavior, validation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->